### PR TITLE
Add biginteger support

### DIFF
--- a/mirage.nimble
+++ b/mirage.nimble
@@ -24,3 +24,5 @@ task fmt, "Format the code":
 
 task docs, "Generate documents":
   exec "nim doc --project --index:on src/mirage.nim"
+
+requires "https://github.com/ferus-web/nim-gmp >= 0.1.0"

--- a/mirage.nimble
+++ b/mirage.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.0.44"
+version       = "1.1.0"
 author        = "xTrayambak"
 description   = "A nifty bytecode generator and runtime"
 license       = "MIT"

--- a/src/mirage/atom.nim
+++ b/src/mirage/atom.nim
@@ -267,7 +267,7 @@ proc null*(): MAtom {.inline, gcsafe, noSideEffect.} =
 proc sequence*(s: seq[MAtom]): MAtom {.inline.} =
   MAtom(kind: Sequence, sequence: s)
 
-proc bigint*(value: uint): MAtom =
+proc bigint*(value: SomeSignedInt): MAtom =
   MAtom(kind: BigInteger, bigint: initBigInt(value))
 
 proc bigint*(value: string): MAtom =

--- a/src/mirage/atom.nim
+++ b/src/mirage/atom.nim
@@ -64,8 +64,6 @@ proc `=destroy`*(dest: MAtom) =
   of Object:
     for atom in dest.objValues:
       `=destroy`(atom)
-  of BigInteger:
-    `=destroy`(dest.bigint) # Free-up the memory that the GNU MP bigint has allocated.
   else:
     discard
 

--- a/src/mirage/atom.nim
+++ b/src/mirage/atom.nim
@@ -267,6 +267,12 @@ proc null*(): MAtom {.inline, gcsafe, noSideEffect.} =
 proc sequence*(s: seq[MAtom]): MAtom {.inline.} =
   MAtom(kind: Sequence, sequence: s)
 
+proc bigint*(value: uint): MAtom =
+  MAtom(kind: BigInteger, bigint: initBigInt(value))
+
+proc bigint*(value: string): MAtom =
+  MAtom(kind: BigInteger, bigint: initBigInt(value))
+
 proc obj*(): MAtom {.inline.} =
   MAtom(kind: Object, objFields: initTable[string, int](), objValues: @[])
 

--- a/src/mirage/atom.nim
+++ b/src/mirage/atom.nim
@@ -4,6 +4,7 @@
 ## Copyright (C) 2024 Trayambak Rai
 
 import std/[strutils, tables, hashes, options]
+import pkg/gmp
 import ./runtime/[shared]
 import ./utils
 
@@ -18,6 +19,7 @@ type
     Boolean = 6
     Object = 7
     Float = 8
+    BigInteger = 9
 
   AtomOverflowError* = object of CatchableError
   SequenceError* = object of CatchableError
@@ -45,6 +47,8 @@ type
     of Null: discard
     of Float:
       floatVal*: float64
+    of BigInteger:
+      bigint*: BigInt
 
   MAtomSeq* = distinct seq[MAtom]
 
@@ -60,6 +64,8 @@ proc `=destroy`*(dest: MAtom) =
   of Object:
     for atom in dest.objValues:
       `=destroy`(atom)
+  of BigInteger:
+    `=destroy`(dest.bigint) # Free-up the memory that the GNU MP bigint has allocated.
   else:
     discard
 
@@ -155,6 +161,8 @@ proc crush*(atom: MAtom, id: string = "", quote: bool = true): string {.inline.}
     result &= $atom.floatVal
   of Null:
     return "NULL"
+  of BigInteger:
+    return $atom.bigint
   of Object:
     return "Object"
 
@@ -288,6 +296,8 @@ proc toString*(atom: MAtom): MAtom {.inline.} =
     return str($atom.floatVal)
   of Null:
     return str "Null"
+  of BigInteger:
+    return str $atom.bigint
 
 proc toInt*(atom: MAtom): MAtom {.inline.} =
   case atom.kind
@@ -311,5 +321,5 @@ proc toInt*(atom: MAtom): MAtom {.inline.} =
     return atom.state.int.integer()
   of Float:
     return integer(atom.floatVal.int)
-  of Object:
+  of Object, BigInteger:
     return integer 0

--- a/src/mirage/runtime/shared.nim
+++ b/src/mirage/runtime/shared.nim
@@ -284,8 +284,7 @@ const
     "POWF": PowerFloat,
     "ADDF": AddFloat,
     "SUBF": SubFloat,
-    "ZRETV": ZeroRetval,
-    "LOADBI": LoadBigInt
+    "ZRETV": ZeroRetval
   }.toTable
 
   OpCodeToString* = static:

--- a/src/mirage/runtime/shared.nim
+++ b/src/mirage/runtime/shared.nim
@@ -284,7 +284,8 @@ const
     "POWF": PowerFloat,
     "ADDF": AddFloat,
     "SUBF": SubFloat,
-    "ZRETV": ZeroRetval
+    "ZRETV": ZeroRetval,
+    "LOADBI": LoadBigInt
   }.toTable
 
   OpCodeToString* = static:

--- a/tests/tpulsararith.nim
+++ b/tests/tpulsararith.nim
@@ -1,17 +1,8 @@
-import std/[tables, options]
+import std/[os, tables, options]
 import mirage/atom
 import mirage/runtime/pulsar/interpreter
 
-let i = newPulsarInterpreter(
-  """
-CLAUSE main
-  1 LOADF   1 2.0 
-  2 LOADF   2 2.0
-  3 POWF    1 2
-  4 CALL    print 1
-END main
-"""
-)
+let i = newPulsarInterpreter(readFile(paramStr(1)))
 
 analyze i
 run i


### PR DESCRIPTION
- **(add) add bigints**
- **(fix) fix compilation error**
- **(add) add `bigint()` functions**
- **(fix) atoms: use `SomeSignedInt` instead of `uint` for bigints**
- **(fix) fix double-free in bigint destructor**
- **(bump) 1.0.44 -> 1.1.0**

Adds a rudimentary `BigInteger` type that uses GMP for arbitary-precision integers.
